### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,21 @@ $ faas-cli build -f text-to-speech.yml
 $ faas-cli deploy -f text-to-speech.yml
 ```
 
+You can build the container image manually and then deploy it to OpenFaaS
+separately: first build the function image and push it to a container registry,
+then deploy it by referencing the image directly:
+
+```
+faas-cli deploy --image=YOUR_REGISTRY/text-to-speech:TAG
+```
+
+Replace `YOUR_REGISTRY/text-to-speech:TAG` with the full image name you pushed
+(for example: `ghcr.io/yourname/text-to-speech:latest`).
+
+> [!IMPORTANT]
+> Note: OpenFaaS Community Edition (CE) requires images to be available in a
+> public container registry.
+
 **Test**
 
 Using `curl`, you can send a string to the function to generate an MP3 of speech:
@@ -28,7 +43,8 @@ $ curl http://localhost:8080/function/text-to-speech \
 -d 'This is a test of OpenFaaS text to speech!' > output.mp3
 ```
 
-Also, you can optionally provide an `X-Language` header for a different language:
+The default language is `en`, but you can optionally provide an `X-Language`
+header for a different language:
 
 ```
 $ curl http://localhost:8080/function/text-to-speech \
@@ -36,4 +52,5 @@ $ curl http://localhost:8080/function/text-to-speech \
 -d 'This is a test of OpenFaaS text to speech!' > output.mp3
 ```
 
-A list of supported languages is [here](https://github.com/pndurette/gTTS#lang_list).
+A partial list of supported language is
+[here](https://gtts.readthedocs.io/en/latest/module.html#localized-accents)


### PR DESCRIPTION
Hi, I've updated the README.md file to include instructions on how to deploy the function separately from the build process, as well as two small fixes in the test section: (`en` is now indicated as the default language, and the link to the list of supported languages has been fixed, since the previous one no longer exists).